### PR TITLE
Adding photon conversion resampling and Geant4 photon daughter cuts

### DIFF
--- a/CommonMC/src/GenerateMuonLife_module.cc
+++ b/CommonMC/src/GenerateMuonLife_module.cc
@@ -100,9 +100,10 @@ namespace mu2e {
 	  if(res->find(part) == res->end()){
 
 	    if(part->genParticle()->generatorId() == GenId::StoppedParticleReactionGun    ||
-		part->genParticle()->generatorId() == GenId::dioTail                       ||
-		part->genParticle()->generatorId().isConversion()  || 
-		part->genParticle()->generatorId() == GenId::ExternalRMC          ||
+		part->genParticle()->generatorId() == GenId::dioTail                      ||
+		part->genParticle()->generatorId().isConversion()                         || 
+		part->genParticle()->generatorId() == GenId::gammaPairProduction          ||
+		part->genParticle()->generatorId() == GenId::ExternalRMC                  ||
 		part->genParticle()->generatorId() == GenId::InternalRMC )
 
 	    {

--- a/EventGenerator/src/GammaConversionGun_module.cc
+++ b/EventGenerator/src/GammaConversionGun_module.cc
@@ -1,0 +1,379 @@
+// Michael MacKenzie, 2019
+// Samples photon conversions stored and outputs e+e- pair conversions
+// Assumes G4 is part of the trigger path, will cause an exception otherwise
+
+// C++ includes
+#include <iostream>
+#include <string>
+#include <cmath>
+#include <memory>
+#include <algorithm>
+
+// cetlib includes
+#include "cetlib_except/exception.h"
+
+// CLHEP includes
+#include "CLHEP/Vector/ThreeVector.h"
+#include "CLHEP/Vector/LorentzVector.h"
+#include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/RandGeneral.h"
+#include "CLHEP/Units/PhysicalConstants.h"
+
+// Framework includes
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art_root_io/TFileService.h"
+
+// Mu2e includes
+#include "ConfigTools/inc/ConfigFileLookupPolicy.hh"
+#include "SeedService/inc/SeedService.hh"
+#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "DataProducts/inc/PDGCode.hh"
+#include "MCDataProducts/inc/GenParticle.hh"
+#include "MCDataProducts/inc/GenParticleCollection.hh"
+#include "MCDataProducts/inc/EventWeight.hh"
+#include "Mu2eUtilities/inc/Table.hh"
+#include "Mu2eUtilities/inc/RootTreeSampler.hh"
+#include "GeneralUtilities/inc/RSNTIO.hh"
+#include "Mu2eG4/inc/findMaterialOrThrow.hh"
+
+// G4 includes.
+#include "G4Material.hh"
+#include "G4ParticleTable.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4ProcessManager.hh"
+#include "G4VProcess.hh"
+#include "G4ProcessVector.hh"
+#include "G4GammaConversion.hh"
+#include "G4VEmModel.hh"
+#include "G4BetheHeitlerModel.hh"
+#include "G4DynamicParticle.hh"
+
+// ROOT includes
+#include "TTree.h"
+#include "TFile.h"
+#include "TH1F.h"
+#include "TH2.h"
+#include "TF1.h"
+
+namespace mu2e {
+
+  //================================================================
+  class GammaConversionGun : public art::EDProducer {
+    int                 verbosityLevel_;
+
+    art::RandomNumberGenerator::base_engine_t& eng_;
+
+    CLHEP::RandFlat     randomFlat_;
+    RootTreeSampler<IO::ConversionPointF> stops_;
+    // PairProduction pairProd_;
+
+    bool doHistograms_;
+    //for restricted space generation
+    double xMin_;
+    double xMax_;
+    double yMin_;
+    double yMax_;
+    double zMin_;
+    double zMax_;
+    double rMin_; //defined from the ds axis
+    double rMax_; 
+    //minimum momentum of a daughter
+    double pMin_;
+    //maximum momentum of a photon
+    double pMax_;
+    //photon cos(theta) restriction
+    double czMin_;
+    double czMax_;
+
+    std::string defaultMat_; //for testing the pair production spectrum for a given material
+    double testE_; //for testing the pair production spectrum for a given Energy
+    
+    bool doOneLepton_; //For only putting the high energy lepton in the event, debug only!
+    
+    double xOffset_; //ds axis x offset
+
+    G4ParticleDefinition* photon_; //for passing into the pair production spectrum
+    G4BetheHeitlerModel* g4bhm_; //pair production spectrum
+    
+    TH1F* _hgencuts; //records number of events attempted
+    TH1F* _hmomentum;
+    TH1F* _hcos;
+    TH1F* _hcosWt;
+    TH1F* _hr; //x-y r from (x,y) = (-3904, 0)
+    TH1F* _hz; 
+    TH1F* _hElecMom  {nullptr};
+    TH1F* _hPosiMom  {nullptr};
+    TH1F* _hTotMom   {nullptr};
+    TH1F* _hTotMomWt {nullptr};
+    TH1F* _hMee;
+    TH2F* _hMeeVsE;
+    TH1F* _hMeeOverE;                   // M(ee)/E(gamma)
+    TH1F* _hy;				// splitting function
+
+  public:
+    explicit GammaConversionGun(const fhicl::ParameterSet& pset);
+    virtual void produce(art::Event& event);
+  };
+
+  //================================================================
+  GammaConversionGun::GammaConversionGun(const fhicl::ParameterSet& pset)
+    : EDProducer{pset}
+    , verbosityLevel_  (pset.get<int>   ("verbosityLevel", 0))
+    , eng_(createEngine(art::ServiceHandle<SeedService>()->getSeed()))
+    , randomFlat_      (eng_)
+    , stops_           (eng_, pset.get<fhicl::ParameterSet>("gammaStops"))
+    // , pairProd_        (&randomFlat_)
+    , doHistograms_    (pset.get<bool>("doHistograms",true ))
+    , xMin_            (pset.get<double>("xMin",-1.e9 ))
+    , xMax_            (pset.get<double>("xMax", 1.e9 ))
+    , yMin_            (pset.get<double>("yMin",-1.e9 ))
+    , yMax_            (pset.get<double>("yMax", 1.e9 ))
+    , zMin_            (pset.get<double>("zMin",-1.e9 ))
+    , zMax_            (pset.get<double>("zMax", 1.e9 ))
+    , rMin_            (pset.get<double>("rMin",-1.e9 ))
+    , rMax_            (pset.get<double>("rMax", 1.e9 ))
+    , pMin_            (pset.get<double>("pMin",  -1. ))
+    , pMax_            (pset.get<double>("pMax",  -1. ))
+    , czMin_           (pset.get<double>("czMin", -1. ))
+    , czMax_           (pset.get<double>("czMax",  1. ))
+    , defaultMat_      (pset.get<std::string>("defaultMaterial", ""))
+    , testE_           (pset.get<double>("testE", -1. ))
+    , doOneLepton_     (pset.get<bool>("doOneLepton", false ))
+    , xOffset_         (pset.get<double>("solenoidXOffset", -3904. ))
+  {
+    produces<mu2e::GenParticleCollection>();
+    produces<mu2e::EventWeight>();
+    produces<GenParticle>("photon"); //store photon generation energy for RMC weights
+
+    photon_ = 0;
+    // objsize_ = sizeof(*photon_) + sizeof(*g4bhm_);
+
+    if(verbosityLevel_ > 0) {
+      std::cout<<"GammaConversionGun: using = "
+               <<stops_.numRecords()
+               <<" stopped gammas"
+               <<std::endl;
+
+      std::cout<<"GammaConversionGun: producing photon " << std::endl;
+    }
+    if(xMin_ >= xMax_ || yMin_ >= yMax_ || zMin_ >= zMax_ || rMin_ >= rMax_)
+      throw cet::exception("BADCONFIG")
+	<< "GammaConversionGun: Stop (x,y,z,r) restriction error! "
+	<< xMin_ << " < x < " << xMax_ << ", "
+	<< yMin_ << " < y < " << yMax_ << ", "
+	<< zMin_ << " < z < " << zMax_ << ", "
+	<< rMin_ << " < r < " << rMax_ << "\n";
+
+    if(doOneLepton_)
+      std::cout << "GammaConversionGun: Warning! Only putting the highest energy lepton in the event!\n";
+    if(defaultMat_.size() > 0)
+      std::cout << "GammaConversionGun: Overriding Ntuple defined material and instead using "
+		<< defaultMat_.c_str() << std::endl;
+    if(testE_ > 0) {
+      std::cout << "GammaConversionGun: Overriding Ntuple defined energy and instead using "
+		<< testE_ << std::endl;
+      if(pMin_ > testE_)
+	throw cet::exception("BADCONFIG")
+	  << "GammaConversionGun: Test energy set to value below minimum electron/positron momentum!\n";
+      if(pMax_ > 0. && pMax_ < testE_)
+	throw cet::exception("BADCONFIG")
+	  << "GammaConversionGun: Test energy set to value above maximum photon momentum!\n";
+
+    }
+
+    //essentially a weight histogram, so store always
+    art::ServiceHandle<art::TFileService> tfs;
+    art::TFileDirectory tfdir = tfs->mkdir( "GammaConversionGun" );
+    _hgencuts  = tfdir.make<TH1F>( "hgencuts", "Attempts to generate vs cut number", 10,  0.5,  10.5  );
+    if ( doHistograms_ ) {
+
+      _hmomentum = tfdir.make<TH1F>("hmomentum", "Given photon momentum", 1000,  0.,  200.  );
+      _hcos      = tfdir.make<TH1F>("hcos"     , "Given photon cos(#theta)", 1000,  -1.,  1.  );
+      _hcosWt    = tfdir.make<TH1F>("hcosWt"   , "Given photon cos(#theta) weighted", 1000,  -1.,  1.  );
+      _hr        = tfdir.make<TH1F>("hr"       , "Given photon radius from the DS axis", 1000,  0.,  2000.  );
+      _hz        = tfdir.make<TH1F>("hz"       , "Given photon Z", 1000,  0., 15000.  );
+      _hElecMom  = tfdir.make<TH1F>("hElecMom" , "Produced electron momentum", 1000,  0. , 200.);
+      _hPosiMom  = tfdir.make<TH1F>("hPosiMom" , "Produced positron momentum", 1000,  0. , 200.);
+      _hTotMom   = tfdir.make<TH1F>("hTotMom"   , "Produced total momentum", 1000.,  0. , 200.);
+      _hTotMomWt = tfdir.make<TH1F>("hTotMomWt" , "Produced total momentum weighted", 1000.,  0. , 200.);
+      _hMee      = tfdir.make<TH1F>("hMee"     , "M(e+e-) "           , 200,0.,200.);
+      _hMeeVsE   = tfdir.make<TH2F>("hMeeVsE"  , "M(e+e-) vs E"       , 200,0.,200.,200,0,200);
+      _hMeeOverE = tfdir.make<TH1F>("hMeeOverE", "M(e+e-)/E "         , 200, 0.,1);
+      _hy        = tfdir.make<TH1F>("hy"       , "y = (ee-ep)/|pe+pp|", 200,-1.,1.);
+
+    }
+
+  }
+
+  //================================================================
+  void GammaConversionGun::produce(art::Event& event) {
+
+    std::unique_ptr<GenParticleCollection> output(new GenParticleCollection);
+    
+    //fields in the stop ntuple 
+    double x, y, z, t, px, py, pz;
+    char* mat = new char[40];
+    double weight;
+    double gen_energy;
+
+    bool passed = false;
+    CLHEP::Hep3Vector pos(0.,0.,0.);
+    CLHEP::HepLorentzVector mome, momp;
+
+    //Get the process information for photon conversions to sample from
+    if(!photon_) {
+      G4ParticleTable* ptable = G4ParticleTable::GetParticleTable();
+      if(ptable) {
+	photon_ = ptable->FindParticle(22);
+	if(photon_) {
+	  const G4ProcessManager* g4pm = photon_->GetProcessManager();
+	  if(g4pm) {
+	    G4VProcess* g4vp = g4pm->GetProcess("conv");
+	    if(g4vp) {
+	      G4GammaConversion* g4pprm = (G4GammaConversion*) g4vp;
+	      if(g4pprm) {
+		G4VEmModel* emmodel = g4pprm->EmModel(0); //BetheHeitler model, E_gamma < 80 GeV
+		if(emmodel) {
+		  g4bhm_ = (G4BetheHeitlerModel*) emmodel;
+		  if(g4bhm_) {
+		    printf("GammaConversionGun::produce : Successfully initialized Bethe Heitler Model\n");
+		  } else
+		    throw cet::exception("ERROR")
+		      << "GammaConversionGun::produce : Failed to initialize Bethe Heitler Model\n";
+		} else
+		  throw cet::exception("ERROR")
+		    << "GammaConversionGun::produce : Failed to initialize EM Model\n";
+	      } else
+		throw cet::exception("ERROR")
+		  << "GammaConversionGun::produce : Failed to initialize GammaConversion process\n";
+	    } else
+	      throw cet::exception("ERROR")
+		<< "GammaConversionGun::produce : Failed to initialize conversion process\n";
+	  } else
+	    throw cet::exception("ERROR")
+	      << "GammaConversionGun::produce : Failed to initialize a process manager \n";
+	} else
+	  throw cet::exception("ERROR")
+	    << "GammaConversionGun::produce : Failed to initialize a G4 photon \n";
+      } else
+	throw cet::exception("ERROR")
+	  << "GammaConversionGun::produce : Failed to initialize a particle table\n";
+    }
+    
+    //loop through generations until an event passes the generation cuts
+    do {
+      const auto& stop = stops_.fire();
+      x  = stop.x;  y  = stop.y;  z  = stop.z;  t = stop.time;
+      px = stop.px; py = stop.py; pz = stop.pz; 
+      if(defaultMat_.size() == 0) sprintf(mat,"%s",stop.mat); 
+      else                        sprintf(mat,"%s",defaultMat_.c_str()); 
+      weight = stop.weight; gen_energy = stop.genEnergy;
+
+      _hgencuts->Fill(1); //all generations
+      passed = !(x < xMin_ || x > xMax_
+		 || y < yMin_ || y > yMax_
+		 || z < zMin_ || z > zMax_
+		 || sqrt((x-xOffset_)*(x-xOffset_) + y*y) < rMin_ 
+		 || sqrt((x-xOffset_)*(x-xOffset_) + y*y) > rMax_ );
+
+      if(!passed) continue;
+      _hgencuts->Fill(2); //passed spacial cut
+      CLHEP::Hep3Vector mom(px, py, pz);
+      if(testE_ > 0.) mom.setMag(testE_);
+      
+      double photonE = mom.mag();
+      passed = passed && (pMax_ < 0. || pMax_ > photonE);
+      if(!passed) continue;
+      _hgencuts->Fill(3); //passed maximum photon momentum cut
+
+      double cz = mom.cosTheta();
+      passed = passed && cz >= czMin_ && cz <= czMax_;
+      if(!passed) continue;
+      _hgencuts->Fill(4); //Cos(theta) cut
+
+      //can't make a daughter of pMin if below already
+      passed = passed && photonE > pMin_;
+      if(!passed) continue;
+      _hgencuts->Fill(5); //passed initial minimum momentum cut
+
+      //sample the spectrum
+      std::vector<G4DynamicParticle*> *g4dpv = new std::vector<G4DynamicParticle*>();
+      G4Material* material = findMaterialOrThrow(mat);
+      G4MaterialCutsCouple* matcut = new G4MaterialCutsCouple(material);
+      mom.setMag(1.); //just need momentum direction with the energy
+      G4DynamicParticle* g4dp = new G4DynamicParticle(photon_, mom, photonE);
+      g4bhm_->SampleSecondaries(g4dpv, matcut, g4dp,0.,0.);
+
+      //get e+- pair
+      mome = (*g4dpv)[0]->Get4Momentum();
+      momp = (*g4dpv)[1]->Get4Momentum();
+
+      //release memory
+      delete g4dp;
+      delete matcut;
+      for(auto dp : *g4dpv)
+	delete dp;
+      delete g4dpv;
+
+      passed = passed && (mome.vect().mag() > pMin_ || momp.vect().mag() > pMin_);
+      if(!passed) continue;
+      _hgencuts->Fill(6); //Final momentum cut
+
+      pos.setX(x); pos.setY(y); pos.setZ(z);
+
+    } while(!passed);
+    _hgencuts->Fill(10); //passing all cuts
+    
+                                                                                   //GenId = 44
+    if(!doOneLepton_ || mome.e() >  momp.e()) output->emplace_back(PDGCode::e_minus, GenId::gammaPairProduction, pos, mome, t);
+    if(!doOneLepton_ || momp.e() >= mome.e()) output->emplace_back(PDGCode::e_plus , GenId::gammaPairProduction, pos, momp, t);
+    event.put(move(output));
+
+    //add event weight and gen photon energy to the output
+    std::unique_ptr<EventWeight> evtwt ( new EventWeight(weight) );
+    event.put(move(evtwt));
+    std::unique_ptr<mu2e::GenParticle> genenergy ( new mu2e::GenParticle(PDGCode::gamma, GenId::ExternalRMC, 
+									 CLHEP::Hep3Vector(0.,0.,0.),
+									 CLHEP::HepLorentzVector(0.,0.,gen_energy,gen_energy),0. ));
+    event.put(move(genenergy),"photon"); 
+
+    //release memory
+    delete [] mat;
+    if ( !doHistograms_ ) return;
+
+    _hcos->Fill((mome+momp).vect().cosTheta());
+    _hcosWt->Fill((mome+momp).vect().cosTheta(),weight);
+    _hr->Fill(sqrt((pos.x()+3904.)*(pos.x()+3904.)+pos.y()*pos.y()));
+    _hz->Fill(pos.z());
+    _hElecMom ->Fill(mome.vect().mag());
+    _hPosiMom ->Fill(momp.vect().mag());
+    CLHEP::Hep3Vector p = mome.vect()+momp.vect();
+    double momentum = p.mag();
+    _hTotMom ->Fill(momentum);
+    _hTotMomWt ->Fill(momentum, weight);
+
+    double mee = (mome+momp).m();
+    _hMee->Fill(mee);
+    double energy = (mome+momp).e();
+    _hMeeVsE->Fill(energy,mee);
+    _hMeeOverE->Fill(mee/energy);
+
+    double lepy = (mome.e()-momp.e())/energy;
+
+    _hy->Fill(lepy);
+
+    
+    _hmomentum->Fill(energy);
+
+  }
+
+
+  //================================================================
+} // namespace mu2e
+
+DEFINE_ART_MODULE(mu2e::GammaConversionGun);

--- a/EventGenerator/src/SConscript
+++ b/EventGenerator/src/SConscript
@@ -16,7 +16,145 @@ crylib = os.environ['CRY_LIB']
 
 rootlibs  = env['ROOTLIBS']
 
+g4inc    = os.environ['G4INCLUDE'] + '/Geant4'
+g4libdir = os.environ['G4LIB']
+g4_version = os.environ['GEANT4_VERSION']
+g4_version=g4_version.replace('_','')
+if g4_version[2] == '9':
+    g4_version = g4_version[1]+'0'+g4_version[2:4]
+else:
+    g4_version = g4_version[1:5]
+
+G4CPPFLAGS = [ '-DG4OPTIMISE',           '-DG4VERBOSE',
+               '-DG4_STORE_TRAJECTORY',  '-DG4UI_USE_TCSH ',
+               '-DG4UI_USE',             '-DG4VIS_USE_DAWNFILE',
+               '-DG4VIS_USE_HEPREPFILE', '-DG4VIS_USE_RAYTRACER',
+               '-DG4VIS_USE_VRMLFILE',   '-DG4VIS_USE_ASCIITREE',
+               '-DG4VIS_USE_GAGTREE',    '-DG4VIS_USE',
+               '-DG4VERSION='+g4_version
+            ]
+
+g4mt = env['G4MT'];
+if g4mt == 'on':
+    G4CPPFLAGS.append('-DG4MULTITHREADED')
+
+g4vis = env['G4VIS'];
+
+if g4vis == 'qt':
+    G4GS_CPPFLAGS = [ '-DG4VIS_USE_OPENGLX',    '-DG4VIS_USE_OPENGL',
+                      '-DG4UI_USE_QT',          '-DG4VIS_USE_OPENGLQT' ]
+elif  g4vis == 'none':
+    G4GS_CPPFLAGS = []
+else:
+    G4GS_CPPFLAGS = [ '-DG4VIS_USE_OPENGLX',    '-DG4VIS_USE_OPENGL' ]
+
+# The granular version of the G4 libraries.
+G4GRANULARLIBS = [
+           'G4error_propagation',                 'G4mctruth',
+           'G4readout',                           'G4phys_lists',
+           'G3toG4',                              'G4phys_builders',
+           'G4gflash',                            'G4visHepRep',
+           'G4biasing',                           'G4FR',
+           'G4OpenGL',                            'G4RayTracer',
+           'G4brep',                              'G4Tree',
+           'G4VRML',                              'G4visXXX',
+           'G4vis_management',                    'G4decay',
+           'G4muons',                             'G4geomBoolean',
+           'G4UIbasic',                           'G4UIGAG',
+           'G4UIcommon',                          'G4emhighenergy',
+           'G4empolar',                           'G4emstandard',
+           'G4hadronic_binary',                   'G4xrays',
+           'G4hadronic_coherent_elastic',         'G4hadronic_abrasion',
+           'G4hadronic_em_dissociation',          'G4partutils',
+           'G4had_lll_fis',                       'G4had_theo_max',
+           'G4run',                               'G4hadronic_bert_cascade',
+           'G4hadronic_hetcpp_evaporation',       'G4hadronic_ablation',
+           'G4had_preequ_exciton',                'G4hadronic_incl_cascade',
+           'G4hadronic_qmd',                      'G4hadronic_stop',
+           'G4hadronic_interface_ci',             'G4hadronic_hetcpp_utils',
+           'G4hadronic_deex_handler',             'G4hadronic_iso',
+           'G4had_neu_hp',                        'G4hadronic_deex_evaporation',
+           'G4hadronic_radioactivedecay',         'G4hadronic_deex_gem_evaporation',
+           'G4had_string_diff',                   'G4hadronic_proc',
+           'G4had_muon_nuclear',                  'G4hadronic_deex_photon_evaporation',
+           'G4emlowenergy',                       'G4hadronic_mgt',
+           'G4scoring',
+           'G4optical',                           'G4hadronic_deex_fission',
+           'G4detutils',                          'G4hadronic_deex_fermi_breakup',
+           'G4parameterisation',                  'G4had_string_frag',
+           'G4hadronic_HE',                       'G4geomdivision',
+           'G4hadronic_qgstring',                 'G4had_string_man',
+           'G4had_im_r_matrix',                   'G4hadronic_deex_management',
+           'G4hadronic_LE',                       'G4hadronic_body_ci',
+           'G4hadronic_RPG',                      'G4hadronic_deex_util',
+           'G4shortlived',                        'G4hadronic_xsect',
+           'G4hadronic_deex_multifragmentation',  'G4had_mod_util',
+           'G4detscorer',                         'G4had_mod_man',
+           'G4hadronic_util',                     'G4transportation',
+           'G4mesons',                            'G4modeling',
+           'G4event',                             'G4geombias',
+           'G4tracking',                          'G4emutils',
+           'G4baryons',                           'G4bosons',
+           'G4leptons',                           'G4ions',
+           'G4cuts',                              'G4detector',
+           'G4specsolids',                        'G4hits',
+           'G4digits',                            'G4csg',
+           'G4hepnumerics',                       'G4navigation',
+           'G4procman',                           'G4volumes',
+           'G4track',                             'G4magneticfield',
+           'G4partman',                           'G4geometrymng',
+           'G4materials',                         'G4graphics_reps',
+           'G4intercoms',                         'G4globman'
+          ,'G4emadjoint',                         'G4partadj',
+           'G4gl2ps',
+           'G4GMocren',
+           'G4hadronic_crosec_ci',
+           'G4hadronic_fragm_ci',
+           'G4hadronic_proc_ci',
+           'G4gdml'
+           ]
+
+# geant4 9.5 and above uses G4GLOBALIBS
+G4GLOBALIBS = [
+              'libG4FR',
+              'libG4GMocren',
+              'libG4RayTracer',
+              'libG4Tree',
+              'libG4VRML',
+              'libG4analysis',
+              'libG4digits_hits',
+              'libG4error_propagation',
+              'libG4event',
+              'libG4geometry',
+              'libG4global',
+              'libG4graphics_reps',
+              'libG4intercoms',
+              'libG4interfaces',
+              'libG4materials',
+              'libG4modeling',
+              'libG4parmodels',
+              'libG4particles',
+              'libG4persistency',
+              'libG4physicslists',
+              'libG4processes',
+              'libG4readout',
+              'libG4run',
+              'libG4track',
+              'libG4tracking',
+              'libG4visHepRep',
+              'libG4visXXX',
+              'libG4vis_management',
+              'libG4zlib'
+              ]
+
+if g4_version < '4095':
+    G4LIBS = G4GRANULARLIBS
+else:
+    G4LIBS = G4GLOBALIBS
+
 mainlib = helper.make_mainlib ( [
+        'mu2e_G4Helper_G4Helper_service',
+        'mu2e_G4Helper',
         'mu2e_Mu2eUtilities',
         'mu2e_ConditionsService',
         'mu2e_GeometryService',
@@ -50,14 +188,19 @@ mainlib = helper.make_mainlib ( [
         'HepPDT',
         'HepPID',
         rootlibs,
+        G4LIBS,
         'boost_system',
         'gsl',
-        ], [],['-I' + cryinc, '-L' + crylib]
+        ],
+                                [  G4CPPFLAGS, G4GS_CPPFLAGS ],
+                                ['-I' + cryinc, '-L' + crylib, '-L'+g4libdir, '-I'+g4inc ]
+
         )
 
 helper.make_plugins( [ mainlib,
                        'mu2e_SeedService_SeedService_service',
                        'mu2e_Mu2eUtilities',
+                       'mu2e_Mu2eG4',
                        'mu2e_ConditionsService',
                        'mu2e_GeometryService',
                        'mu2e_GlobalConstantsService',
@@ -84,6 +227,7 @@ helper.make_plugins( [ mainlib,
                        'fhiclcpp',
                        'cetlib',
                        'cetlib_except',
+                       G4LIBS,
                        'CLHEP',
                        'HepPDT',
                        'HepPID',
@@ -93,7 +237,10 @@ helper.make_plugins( [ mainlib,
                        'gsl',
                        'CRY',
                      ],
-                    [], ['-I' + cryinc], ['-L' + crylib])
+                     [],
+                     [ G4CPPFLAGS, G4GS_CPPFLAGS ],
+                     ['-I' + cryinc, '-L' + crylib, '-L'+g4libdir, '-I'+g4inc ]
+)
 
 # This tells emacs to view this file in python mode.
 # Local Variables:

--- a/EventGenerator/test/gammaConversion_test.fcl
+++ b/EventGenerator/test/gammaConversion_test.fcl
@@ -1,0 +1,61 @@
+# -*- mode:tcl -*-
+#include "JobConfig/primary/flatE.fcl"
+
+process_name: conversionsampler
+
+services.TimeTracker : {
+	printSummary : true
+	dbOutput : {
+	    filename  : ""
+	    overwrite : false
+	}
+    }
+services.scheduler.wantSummary: true
+
+physics : {
+    producers : { @table::Primary.producers
+	generate: {  module_type: GammaConversionGun
+	    verbositylevel : 0	  
+	    doHistograms   : true
+	    gammaStops: {
+		@table::muonStops
+		branchName: "stops"
+		treeName: "conversionwriter/gammaStops/conversions"
+	    }
+	    # pMax  : 93.0 // MeV, maximum photon energy
+	    # pMin  : 84.5 // MeV, minimum daughter energy
+	    # czMin : -0.2 // minimum photon cos(theta)
+	    # czMax :  0.2 // maximum photon cos(theta)
+	    # testE : 90
+	    # testZ : 13
+	    # doOneLepton : true //only put high energy lepton in the event
+	    # xMin  : -4904
+	    # xMax  : -2904
+	    # yMin  : -1000
+	    # yMax  :  1000
+	    # zMin  :  3500
+	    # zMax  :  8000
+	    # rMin  :  0
+	    # rMax  :  500	    
+	}
+    }
+    analyzers : { @table::Primary.analyzers }
+    filters :   { @table::Primary.filters   }
+    e1 : [ ] 
+    p1 : [ generate, g4run ]
+    trigger_paths : [ p1 ]
+    end_paths : [ e1 ]
+}
+
+#include "JobConfig/primary/epilog.fcl"
+
+#To speed up test running
+physics.producers.g4run.physics.physicsListName : "QGSP_BERT"
+
+
+services.TFileService.fileName: "nts.owner.conversionsampler.version.sequencer.root"
+outputs.Output.fileName:        "dig.owner.conversionsampler.version.sequencer.art"
+#hack to access the root file on /pnfs/mu2e/resilient/
+#can instead put the file in the $MU2E_BASE_RELEASE directory to run until is in /cvmfs/mu2e.opensciencegrid.org/DataFiles/
+physics.producers.generate.gammaStops.inputFiles : [ "../../../pnfs/mu2e/resilient/users/mmackenz/gammastops/gamma_stops.root" ]
+

--- a/Filters/src/GammaConversionPoints_module.cc
+++ b/Filters/src/GammaConversionPoints_module.cc
@@ -230,7 +230,9 @@ namespace mu2e {
 	    const std::string& materialName = endVolParent.materialName();
 	    hStoppingMat_->Fill(materialName.c_str(), 1.);
 	    if(materialName.size() > 40) 
-	      printf("Warning! Material name longer than material name array! (%s)\n", materialName.c_str());
+	      printf("GammaConverionPoints::%s: Warning! Material name longer than material name array! (%s)\n", 
+		     __func__, materialName.c_str());
+
 	    sprintf(data_.mat, "%s",materialName.c_str());
 	    // std::cout << "mat : " << data_.mat << " material : " << materialName.c_str() << std::endl;
 	  } else sprintf(data_.mat,"%s",defaultMat_.c_str());

--- a/Filters/src/GammaConversionPoints_module.cc
+++ b/Filters/src/GammaConversionPoints_module.cc
@@ -1,0 +1,261 @@
+//
+// Largely based on Filters/src/InflightPionHits and Analyses/src/StoppedParticleFinder
+// Finds and writes out information for generated photons that pair produce
+// Writes conversion point x, y, z, t, px, py, pz, material, event weight, and gen energy
+
+// Mu2e includes.
+#include "MCDataProducts/inc/GenParticleCollection.hh"
+#include "MCDataProducts/inc/StatusG4.hh"
+#include "MCDataProducts/inc/StepPointMCCollection.hh"
+#include "MCDataProducts/inc/SimParticleCollection.hh"
+#include "MCDataProducts/inc/SimParticle.hh"
+#include "MCDataProducts/inc/SimParticleTimeMap.hh"
+#include "MCDataProducts/inc/EventWeight.hh"
+#include "MCDataProducts/inc/PhysicalVolumeInfoMultiCollection.hh"
+#include "Mu2eUtilities/inc/PhysicalVolumeMultiHelper.hh"
+#include "Mu2eG4/inc/findMaterialOrThrow.hh"
+
+// G4 includes.
+#include "G4Material.hh"
+
+// Framework includes.
+#include "canvas/Persistency/Common/Ptr.h"
+#include "art/Framework/Core/EDFilter.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art_root_io/TFileService.h"
+
+// Root includes
+#include "TH1F.h"
+#include "TH1D.h"
+#include "TTree.h"
+
+// Other includes
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+// C++ includes
+#include <iostream>
+
+using namespace std;
+
+namespace mu2e {
+
+  namespace {
+    struct StopInfo {
+      float x;
+      float y;
+      float z;
+      float time;
+      float px;
+      float py;
+      float pz;
+      float weight;    // for generation weights
+      float genEnergy; // for RMC weights
+      char  mat[40]; // material converted in
+
+      StopInfo() : x(), y(), z(), time(), px(), py(), pz(), weight(), genEnergy(), mat() {}
+    };
+  }
+
+  class GammaConversionPoints : public art::EDFilter {
+  public:
+    explicit GammaConversionPoints(fhicl::ParameterSet const& pset);
+    virtual ~GammaConversionPoints() { }
+
+    bool filter( art::Event& event);
+
+    virtual bool beginRun(art::Run &run);
+    bool beginSubRun(art::SubRun& sr) override;
+
+    virtual void endJob();
+
+  private:
+
+    // Module label of the module that made the StepPointMCCollections.
+    std::string g4ModuleLabel_;
+    std::string simCollectionLabel_;
+    std::string generatorLabel_;
+
+    std::string defaultMat_; //default to use if defined
+    bool doFilter_; //whether or not to filter non-conversions
+    double rMin_; //spacial cuts
+    double rMax_; //
+    double zMin_; //
+    double zMax_; //
+    double xoffset_; // detector solenoid x offset 
+    
+    TH1F* hStoppingcode_;
+    TH1D* hStoppingMat_;
+    TTree* ntup_;
+
+    // Number of events that pass the filter.
+    int nPassed_;
+
+    //struct of stop info
+    StopInfo data_;
+
+    const PhysicalVolumeInfoMultiCollection *vols_;
+
+  };
+
+  GammaConversionPoints::GammaConversionPoints(fhicl::ParameterSet const& pset):
+    art::EDFilter{pset},
+    g4ModuleLabel_(pset.get<string>("g4ModuleLabel")),
+    simCollectionLabel_(pset.get<string>("simCollectionLabel","")),
+    generatorLabel_(pset.get<string>("generatorLabel","")),
+    defaultMat_(pset.get<string>("defaultMat", "")),
+    doFilter_(pset.get<bool>("doFilter", false)),
+    rMin_(pset.get<double>("rMin",-1.)),
+    rMax_(pset.get<double>("rMax", 1.e9)),
+    zMin_(pset.get<double>("zMin",-1.e9)),
+    zMax_(pset.get<double>("zMax", 1.e9)),
+    xoffset_(pset.get<double>("SolenoidXOffset", -3904.)),
+    hStoppingcode_(0),
+    hStoppingMat_(0),
+    ntup_(0),
+    nPassed_(0),
+    data_() {
+      if(defaultMat_.size() > 0)
+	printf("GammaConversionPionts: Using %s material for all stops!\n", defaultMat_.c_str());
+      if(generatorLabel_.size() == 0)
+	printf("GammaConversionPionts: No generator label passed, assuming all events have weight 1\n");
+      art::ServiceHandle<art::TFileService> tfs;
+      art::TFileDirectory tfdir = tfs->mkdir( "gammaStops" );
+      
+      hStoppingcode_  = tfdir.make<TH1F>( "hStoppingcode", "Photon stopping code",   200, 0.,  200.);
+      hStoppingMat_  = tfdir.make<TH1D>( "hStoppingMat", "Photon stopping material",  1, 0.,  1.);
+    
+      ntup_ = tfdir.make<TTree>( "conversions", "Photon Conversions");
+      ntup_->Branch("stops", &data_, "x/F:y/F:z/F:time/F:px/F:py/F:pz/F:weight/F:genEnergy/F:mat/C");
+
+    }  
+
+  bool GammaConversionPoints::beginSubRun(art::SubRun& sr) {
+    if(defaultMat_.size() > 0) return true; //assuming a material so don't need the volume info
+    art::Handle<PhysicalVolumeInfoMultiCollection> volh;
+    sr.getByLabel(g4ModuleLabel_, volh);
+    vols_ = &*volh;
+    return true;
+  }
+
+  bool GammaConversionPoints::beginRun(art::Run& ){
+
+    return true;
+  }
+
+  bool
+  GammaConversionPoints::filter(art::Event& event) {
+    
+    art::Handle<StatusG4> g4StatusHandle;
+    event.getByLabel( g4ModuleLabel_, g4StatusHandle);
+    StatusG4 const& g4Status = *g4StatusHandle;
+
+    // Accept only events with good status from G4.
+    if ( g4Status.status() > 1 ) {
+      return false;
+    }
+
+    art::Handle<SimParticleCollection> simsHandle;
+    event.getByLabel((simCollectionLabel_.size() > 0) ? simCollectionLabel_ : g4ModuleLabel_,simsHandle);
+    SimParticleCollection const& sims(*simsHandle);
+    
+    float weight = (generatorLabel_.size() > 0) ? event.getValidHandle<EventWeight>(generatorLabel_)->weight() : 1.;
+    // printf("weight = %.4f\n", weight);
+    //loop through sim particles looking for gen particle
+    for(auto const& sim : sims) {
+      //check if the generated particle
+      if(sim.second.creationCode() == ProcessCode::mu2ePrimary) {
+	SimParticle const& parent = sim.second;
+	hStoppingcode_->Fill(parent.stoppingCode());
+	//check if pair conversion
+	if(parent.pdgId() == 22 && ProcessCode::conv == parent.stoppingCode()) {
+	  //get end position and momentum vectors
+	  CLHEP::Hep3Vector const&       pos(parent.endPosition());
+	  //check if it's within the region of interest
+	  double r = sqrt((pos.x()-xoffset_)*(pos.x()-xoffset_) + pos.y()*pos.y());
+	  if(r < rMin_ || r > rMax_ || pos.z() < zMin_ || pos.z() > zMax_) return !doFilter_;
+
+	  CLHEP::Hep3Vector const&       p(parent.endMomentum().vect());
+	  CLHEP::Hep3Vector const&       pStart(parent.startMomentum().vect()); //for RMC weight energy or if needed for momentum
+	  CLHEP::Hep3Vector pstart(pStart.x(), pStart.y(), pStart.z()); //to edit the vector
+	  bool useStart = false;
+	  
+	  if(p.mag() == 0.) { //in case the final momentum not saved, add the daughters
+	    std::vector<art::Ptr<SimParticle> > const& daughters = parent.daughters();
+	    if(daughters.size() < 1) {
+	      useStart = true; //no daughters saved
+	    } else {
+	      CLHEP::Hep3Vector pp(0.,0.,0.);
+	      int nConv = 0;
+	      for(unsigned int i = 0; i < daughters.size(); ++i) {
+		SimParticle const sp = *daughters[i];
+		if(sp.creationCode() == ProcessCode::conv) {
+		  ++nConv;
+		  pp += sp.startMomentum().vect();
+		} else { //remove other daughters as happening before the conversion in case not all conversions found
+		  pstart -= sp.startMomentum().vect();		  
+		}
+	      }
+	      if(nConv < 2) { //both conversion daughters weren't stored
+		useStart = true;
+	      }
+	      else { //both daughters stored
+		data_.px = pp.x();
+		data_.py = pp.y();
+		data_.pz = pp.z();
+	      }
+	    }
+	  } else { //end momentum is stored
+	    data_.px = p.x();
+	    data_.py = p.y();
+	    data_.pz = p.z();
+	  }
+	  if(useStart) { //if conversion daughters not stored and end momentum not stored
+	    data_.px = pstart.x();
+	    data_.py = pstart.y();
+	    data_.pz = pstart.z();
+	  }
+
+	  data_.x = pos.x();
+	  data_.y = pos.y();
+	  data_.z = pos.z();
+	  data_.time = parent.endGlobalTime();
+	  data_.weight = weight;
+	  data_.genEnergy = pStart.mag();
+
+	  if(defaultMat_.size() == 0) { //find actual Z of the material
+	    PhysicalVolumeMultiHelper vi(*vols_);
+	    PhysicalVolumeInfo const& endVolParent = vi.endVolume(parent);
+	    const std::string& materialName = endVolParent.materialName();
+	    hStoppingMat_->Fill(materialName.c_str(), 1.);
+	    if(materialName.size() > 40) 
+	      printf("Warning! Material name longer than material name array! (%s)\n", materialName.c_str());
+	    sprintf(data_.mat, "%s",materialName.c_str());
+	    // std::cout << "mat : " << data_.mat << " material : " << materialName.c_str() << std::endl;
+	  } else sprintf(data_.mat,"%s",defaultMat_.c_str());
+
+	  ntup_->Fill();
+	  ++nPassed_; 
+	  return true; //converted so done looking
+	} else return !doFilter_; //not a conversion
+      } 
+    }
+
+    return !doFilter_;
+
+  } // end of ::filter.
+
+  void GammaConversionPoints::endJob() {
+    mf::LogInfo("Summary") 
+      << "GammaConversionPoints_module: Number of conversion events found: " 
+      << nPassed_
+      << "\n";
+  }
+
+} //end mu2e namespace
+
+using mu2e::GammaConversionPoints;
+DEFINE_ART_MODULE(GammaConversionPoints);
+
+

--- a/Filters/src/SConscript
+++ b/Filters/src/SConscript
@@ -14,6 +14,167 @@ helper=mu2e_helper(env)
 babarlibs = env['BABARLIBS']
 rootlibs  = env['ROOTLIBS']
 
+g4inc    = os.environ['G4INCLUDE'] + '/Geant4'
+g4libdir = os.environ['G4LIB']
+g4_version = os.environ['GEANT4_VERSION']
+g4_version=g4_version.replace('_','')
+if g4_version[2] == '9':
+    g4_version = g4_version[1]+'0'+g4_version[2:4]
+else:
+    g4_version = g4_version[1:5]
+
+# print "GEANT4_VERSION ",  g4_version
+
+# Compiler switches needed by the default G4 build.
+G4CPPFLAGS = [ '-DG4OPTIMISE',           '-DG4VERBOSE',
+               '-DG4_STORE_TRAJECTORY',  '-DG4UI_USE_TCSH ',
+               '-DG4UI_USE',             '-DG4VIS_USE_DAWNFILE',
+               '-DG4VIS_USE_HEPREPFILE', '-DG4VIS_USE_RAYTRACER',
+               '-DG4VIS_USE_VRMLFILE',   '-DG4VIS_USE_ASCIITREE',
+               '-DG4VIS_USE_GAGTREE',    '-DG4VIS_USE',
+               '-DG4VERSION='+g4_version
+            ]
+
+g4mt = env['G4MT'];
+if g4mt == 'on':
+    G4CPPFLAGS.append('-DG4MULTITHREADED')
+
+# Compiler switches if we want to build G4 with OPENGL and possibly Qt
+
+g4vis = env['G4VIS'];
+
+if g4vis == 'qt':
+    G4GS_CPPFLAGS = [ '-DG4VIS_USE_OPENGLX',    '-DG4VIS_USE_OPENGL',
+                      '-DG4UI_USE_QT',          '-DG4VIS_USE_OPENGLQT' ]
+elif  g4vis == 'none':
+    G4GS_CPPFLAGS = []
+else:
+    G4GS_CPPFLAGS = [ '-DG4VIS_USE_OPENGLX',    '-DG4VIS_USE_OPENGL' ]
+
+# print "mu2eopts      ",  mu2eopts
+# print "G4GS_CPPFLAGS ",  G4GS_CPPFLAGS
+
+# The granular version of the G4 libraries.
+G4GRANULARLIBS = [
+           'G4error_propagation',                 'G4mctruth',
+           'G4readout',                           'G4phys_lists',
+           'G3toG4',                              'G4phys_builders',
+           'G4gflash',                            'G4visHepRep',
+           'G4biasing',                           'G4FR',
+           'G4OpenGL',                            'G4RayTracer',
+           'G4brep',                              'G4Tree',
+           'G4VRML',                              'G4visXXX',
+           'G4vis_management',                    'G4decay',
+           'G4muons',                             'G4geomBoolean',
+           'G4UIbasic',                           'G4UIGAG',
+           'G4UIcommon',                          'G4emhighenergy',
+           'G4empolar',                           'G4emstandard',
+           'G4hadronic_binary',                   'G4xrays',
+           'G4hadronic_coherent_elastic',         'G4hadronic_abrasion',
+           'G4hadronic_em_dissociation',          'G4partutils',
+           'G4had_lll_fis',                       'G4had_theo_max',
+           'G4run',                               'G4hadronic_bert_cascade',
+           'G4hadronic_hetcpp_evaporation',       'G4hadronic_ablation',
+           'G4had_preequ_exciton',                'G4hadronic_incl_cascade',
+           'G4hadronic_qmd',                      'G4hadronic_stop',
+           'G4hadronic_interface_ci',             'G4hadronic_hetcpp_utils',
+           'G4hadronic_deex_handler',             'G4hadronic_iso',
+           'G4had_neu_hp',                        'G4hadronic_deex_evaporation',
+           'G4hadronic_radioactivedecay',         'G4hadronic_deex_gem_evaporation',
+           'G4had_string_diff',                   'G4hadronic_proc',
+           'G4had_muon_nuclear',                  'G4hadronic_deex_photon_evaporation',
+           'G4emlowenergy',                       'G4hadronic_mgt',
+           'G4scoring',
+           'G4optical',                           'G4hadronic_deex_fission',
+           'G4detutils',                          'G4hadronic_deex_fermi_breakup',
+           'G4parameterisation',                  'G4had_string_frag',
+           'G4hadronic_HE',                       'G4geomdivision',
+           'G4hadronic_qgstring',                 'G4had_string_man',
+           'G4had_im_r_matrix',                   'G4hadronic_deex_management',
+           'G4hadronic_LE',                       'G4hadronic_body_ci',
+           'G4hadronic_RPG',                      'G4hadronic_deex_util',
+           'G4shortlived',                        'G4hadronic_xsect',
+           'G4hadronic_deex_multifragmentation',  'G4had_mod_util',
+           'G4detscorer',                         'G4had_mod_man',
+           'G4hadronic_util',                     'G4transportation',
+           'G4mesons',                            'G4modeling',
+           'G4event',                             'G4geombias',
+           'G4tracking',                          'G4emutils',
+           'G4baryons',                           'G4bosons',
+           'G4leptons',                           'G4ions',
+           'G4cuts',                              'G4detector',
+           'G4specsolids',                        'G4hits',
+           'G4digits',                            'G4csg',
+           'G4hepnumerics',                       'G4navigation',
+           'G4procman',                           'G4volumes',
+           'G4track',                             'G4magneticfield',
+           'G4partman',                           'G4geometrymng',
+           'G4materials',                         'G4graphics_reps',
+           'G4intercoms',                         'G4globman'
+          ,'G4emadjoint',                         'G4partadj',
+           'G4gl2ps',
+           'G4GMocren',
+           'G4hadronic_crosec_ci',
+           'G4hadronic_fragm_ci',
+           'G4hadronic_proc_ci',
+           'G4gdml'
+           ]
+
+# geant4 9.5 and above uses G4GLOBALIBS
+G4GLOBALIBS = [
+              'libG4FR',
+              'libG4GMocren',
+              'libG4RayTracer',
+              'libG4Tree',
+              'libG4VRML',
+              'libG4analysis',
+              'libG4digits_hits',
+              'libG4error_propagation',
+              'libG4event',
+              'libG4geometry',
+              'libG4global',
+              'libG4graphics_reps',
+              'libG4intercoms',
+              'libG4interfaces',
+              'libG4materials',
+              'libG4modeling',
+              'libG4parmodels',
+              'libG4particles',
+              'libG4persistency',
+              'libG4physicslists',
+              'libG4processes',
+              'libG4readout',
+              'libG4run',
+              'libG4track',
+              'libG4tracking',
+              'libG4visHepRep',
+              'libG4visXXX',
+              'libG4vis_management',
+              'libG4zlib'
+              ]
+
+if g4vis != 'none':
+    G4GLOBALIBS.append('libG4OpenGL')
+    G4GLOBALIBS.append('libG4gl2ps')
+
+if g4_version < '4095':
+    G4LIBS = G4GRANULARLIBS
+else:
+    G4LIBS = G4GLOBALIBS
+
+# Link libraries needed to build G4 with OPENGL and possibly Qt
+#OPENGL_LIBS = [ 'GLU', 'GL' ]
+
+#if g4vis == 'qt':
+#    GS_LIBS = [ 'GLU', 'GL', 'QtOpenGL', 'QtGui', 'QtCore' ]
+#else:
+#    GS_LIBS = [ 'GLU', 'GL']
+
+# it looks like we do not need them, so we use an empty list before we
+# remove it from here
+GS_LIBS = []
+
+
 #mainlib = helper.make_mainlib ( [
 #    'art_Framework_Core',
 #    'art_Framework_IO_ProductMix',
@@ -21,14 +182,77 @@ rootlibs  = env['ROOTLIBS']
 #    'mu2e_RecoDataProducts',
 #    'mu2e_GeneralUtilities',
 #    ] )
+# Link libraries needed to build G4 with XERCESC
+XERCESC_LIBS = [ 'xerces-c' ]
+
+
+mainlib = helper.make_mainlib ( [
+        'mu2e_G4Helper_G4Helper_service',
+        'mu2e_G4Helper',
+        'mu2e_SeedService_SeedService_service',
+        'mu2e_Mu2eUtilities',
+        'mu2e_GeometryService',
+        'mu2e_MCDataProducts',
+        'mu2e_BeamlineGeom',
+        'mu2e_BFieldGeom',
+        'mu2e_CalorimeterGeom',
+        'mu2e_CosmicRayShieldGeom',
+        'mu2e_DetectorSolenoidGeom',
+        'mu2e_ExternalShieldingGeom',
+        'mu2e_ExtinctionMonitorFNAL_Geometry',
+        'mu2e_MECOStyleProtonAbsorberGeom',
+        'mu2e_Mu2eHallGeom',
+        'mu2e_ProductionSolenoidGeom',
+        'mu2e_ProductionTargetGeom',
+        'mu2e_ProtonBeamDumpGeom',
+        'mu2e_StoppingTargetGeom',
+        'mu2e_TrackerGeom',
+        'mu2e_GeomPrimitives',
+        'mu2e_GlobalConstantsService',
+        'mu2e_ConfigTools',
+        'mu2e_Mu2eInterfaces',
+        'mu2e_DataProducts',
+        'mu2e_RecoDataProducts',
+        'mu2e_GeneralUtilities',
+        babarlibs,
+        'art_Persistency_Provenance',
+        'art_Persistency_Common',
+        'art_Framework_Services_Registry',
+        'art_root_io_TFileService_service',
+        'art_root_io_tfile_support',
+        'art_Framework_Principal',
+        'art_Framework_Core',
+        'art_Framework_IO_ProductMix',
+        'art_Utilities',
+        'canvas',
+        'fhiclcpp',
+        'MF_MessageLogger',
+        'cetlib',
+        'cetlib_except',
+        'HepPDT',
+        G4LIBS,
+        GS_LIBS,
+        XERCESC_LIBS,
+        'CLHEP',
+        'Hist', 'Tree', 'Core',
+        'boost_regex',
+        'boost_system',
+    ],
+                                [  G4CPPFLAGS, G4GS_CPPFLAGS ],
+                                [ '-L'+g4libdir, '-I'+g4inc ]
+                                )
 
 helper.make_plugins( [
-  'mu2e_SeedService_SeedService_service',
+    mainlib,
+    'mu2e_SeedService_SeedService_service',
     'mu2e_Mu2eUtilities',
+    'mu2e_Mu2eG4',
+    'mu2e_Mu2eBTrk',
     'mu2e_CaloCluster',
-    'mu2e_MCDataProducts',
-    'mu2e_RecoDataProducts',
+    'mu2e_GeometryService_GeometryService_service',
     'mu2e_GeometryService',
+    'mu2e_Mu2eHallGeom',
+    'mu2e_MCDataProducts',
     'mu2e_CalorimeterGeom',
     'mu2e_CosmicRayShieldGeom',
     'mu2e_ExtinctionMonitorFNAL_Geometry',
@@ -37,7 +261,14 @@ helper.make_plugins( [
     'mu2e_Mu2eInterfaces',
     'mu2e_DataProducts',
     'mu2e_GeneralUtilities',
-    babarlibs,
+    'MF_MessageLogger',
+    'CLHEP',
+    'HepPDT',
+    'boost_filesystem',
+    'boost_system',
+    'mu2e_RecoDataProducts',
+    'mu2e_Mu2eInterfaces',
+    'mu2e_ConfigTools',
     'art_Framework_Core',
     'art_Framework_Principal',
     'art_Framework_Services_Registry',
@@ -52,12 +283,59 @@ helper.make_plugins( [
     'fhiclcpp',
     'cetlib',
     'cetlib_except',
+    G4LIBS,
+    GS_LIBS,
+    XERCESC_LIBS,
     'CLHEP',
-    'HepPDT',
+    'Tree', 'Core',
     rootlibs,
+    babarlibs,
     'boost_filesystem',
     'boost_system',
-    ] )
+    ],
+                     [],
+                     [ G4CPPFLAGS, G4GS_CPPFLAGS ],
+                     [ '-L'+g4libdir, '-I'+g4inc ]
+                     )
+
+# helper.make_plugins( [
+#     mainlib,                     
+#   'mu2e_SeedService_SeedService_service',
+#     'mu2e_Mu2eUtilities',
+#     'mu2e_CaloCluster',
+#     'mu2e_MCDataProducts',
+#     'mu2e_RecoDataProducts',
+#     'mu2e_GeometryService',
+#     'mu2e_CalorimeterGeom',
+#     'mu2e_CosmicRayShieldGeom',
+#     'mu2e_ExtinctionMonitorFNAL_Geometry',
+#     'mu2e_GlobalConstantsService_GlobalConstantsService_service',
+#     'mu2e_GlobalConstantsService',
+#     'mu2e_Mu2eInterfaces',
+#     'mu2e_DataProducts',
+#     'mu2e_GeneralUtilities',
+#     babarlibs,
+#     'art_Framework_Core',
+#     'art_Framework_Principal',
+#     'art_Framework_Services_Registry',
+#     'art_root_io_tfile_support',
+#     'art_root_io_TFileService_service',
+#     'art_Framework_Services_Optional_RandomNumberGenerator_service',
+#     'art_Persistency_Common',
+#     'art_Persistency_Provenance',
+#     'art_Utilities',
+#     'canvas',
+#     'MF_MessageLogger',
+#     'fhiclcpp',
+#     'cetlib',
+#     'cetlib_except',
+#     'CLHEP',
+#     'HepPDT',
+#     rootlibs,
+#     'boost_filesystem',
+#     'boost_system',
+#     ]
+#                  )
 
 #helper.make_dict_and_map( [
 #    mainlib,

--- a/GeneralUtilities/inc/RSNTIO.hh
+++ b/GeneralUtilities/inc/RSNTIO.hh
@@ -63,6 +63,29 @@ namespace mu2e {
     };
 
     //================================================================
+    //For resampling photon conversions
+    struct ConversionPointF {
+      float x;
+      float y;
+      float z;
+      float time;
+      float px;
+      float py;
+      float pz;
+      float weight;
+      float genEnergy;
+      char  mat[40];
+
+      ConversionPointF() : x(), y(), z(), time(), px(), py(), pz(), weight(), genEnergy(), mat() {}
+
+      static const char *branchDescription() {
+        return "x/F:y/F:z/F:time/F:px/F:py/F:pz/F:weight/F:genEnergy/F:mat/C";
+      }
+
+      static unsigned numBranchLeaves() { return 10; }
+    };
+
+    //================================================================
 
   } // IO
 } // mu2e

--- a/MCDataProducts/inc/GenId.hh
+++ b/MCDataProducts/inc/GenId.hh
@@ -45,7 +45,7 @@ namespace mu2e {
       fromSimParticleStartPoint, fromSimParticleCompact, StoppedParticleG4Gun, //33
       CaloCalib, InFlightParticleSampler, muplusDecayGun, StoppedMuonXRayGammaRayGun, //37
       cosmicCRY, pbarFlat, fromAscii, ExternalRMC, InternalRMC, CeLeadingLog, //43
-      lastEnum //44
+      gammaPairProduction, lastEnum //45
     };
 
     // Keep this in sync with the enum. Used in GenId.cc
@@ -60,7 +60,8 @@ namespace mu2e {
       "MARS", "StoppedParticleReactionGun","bremElectronGun", "muonicXRayGun", \
       "fromSimParticleStartPoint", "fromSimParticleCompact", "StoppedParticleG4Gun", \
       "CaloCalib", "InFlightParticleSampler","muplusDecayGun", "StoppedMuonXRayGammaRayGun", \
-      "CosmicCRY","pbarFlat","fromAscii","ExternalRMC","InternalRMC","CeLeadingLog"
+      "CosmicCRY","pbarFlat","fromAscii","ExternalRMC","InternalRMC","CeLeadingLog", \
+      "gammaPairProduction"
 
   public:
 

--- a/Mu2eG4/inc/Mu2eG4SteppingAction.hh
+++ b/Mu2eG4/inc/Mu2eG4SteppingAction.hh
@@ -105,6 +105,16 @@ namespace mu2e {
     // Store trajectory parameters at each G4Step; cleared at beginOfTrack time.
     std::vector<MCTrajectoryPoint> _trajectory;
 
+    // Values to kill low momentum RMC tracks
+    //minimum energy a daughter must have, <= 0 to not kill tracks
+    double minRMCConversionEnergy_;
+    //maximum endpoint value intended with dataset, assumed partner of a given track could have
+    // this energy when deciding whether or not to kill the track if haven't found energy  yet
+    double processRMCMaxEndpoint_;
+    //photon's energy in current event 
+    double rmcPhotonEnergy_;
+    int    rmcAccepted_; // 0 = undetermined, -1 = kill event, 1 = accept event
+
     // Lists of events and tracks for which to enable debug printout.
     EventNumberList _debugEventList;
     EventNumberList _debugTrackList;
@@ -121,6 +131,9 @@ namespace mu2e {
 
     // Functions to decide whether or not to kill tracks.
     bool killTooManySteps ( const G4Track* const);
+
+    // Function to decide whether or not to kill an RMC daughter track.
+    bool killLowMomentumGammaDaughters( const G4Track* const track);
 
     // A helper function to kill the track and record the reason for killing it.
     void killTrack( G4Track* track, ProcessCode::enum_type code, G4TrackStatus status );


### PR DESCRIPTION
Adds a new event generator, with a corresponding GenId, for re-sampling photon conversions, test
fcl is added to show the use.
A filter is added to write out photon conversion locations to a ntuple that can then be read by the re-sampler.
Also updates the Geant4 user stepping action to allow for event killing if a simulated photon doesn't create a high enough energy daughter.